### PR TITLE
Add SPICS1 pin mapping to GPIO26.

### DIFF
--- a/ESP32-S3_DevKitM-1.md
+++ b/ESP32-S3_DevKitM-1.md
@@ -47,6 +47,7 @@ Testing with a ["Hello World" Example](https://github.com/diplfranzhoepfinger/es
 | USB_D-   | 13         | J3-20            | 0.0V            | I/O/T | RTC_GPIO19, GPIO19, U1RTS, ADC2_CH8, CLK_OUT2, **USB_D-**                                          |
 | USB_D+   | 14         | J3-19            | 3.3V            | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | J3-18            | 0.0V            | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
+| SPICS1   | 28         | J3-17            |                 | I/O/T | SPICS1, **GPIO26**                                                                                 |
 | GPIO35   | 28         | J3-14            | 0.0V            | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | J3-13            | 0.0V            | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | J3-12            | 0.0V            | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |

--- a/ESP32-S3_DevKitM-1.md
+++ b/ESP32-S3_DevKitM-1.md
@@ -48,7 +48,8 @@ Testing with a ["Hello World" Example](https://github.com/diplfranzhoepfinger/es
 | USB_D+   | 14         | J3-19            | 3.3V            | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | J3-18            | 0.0V            | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
 | SPICS1   | 28         | J3-17            |                 | I/O/T | SPICS1, **GPIO26**                                                                                 |
-| SPICS1   | 28         | J3-16            |                 | I/O/T | **GPIO33**                                                                                 |
+| GPIO33   | 28         | J3-16            |                 | I/O/T | **GPIO33**                                                                                         |
+| GPIO34   | 28         | J3-15            |                 | I/O/T | **GPIO34**                                                                                         |
 | GPIO35   | 28         | J3-14            | 0.0V            | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | J3-13            | 0.0V            | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | J3-12            | 0.0V            | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |

--- a/ESP32-S3_DevKitM-1.md
+++ b/ESP32-S3_DevKitM-1.md
@@ -48,6 +48,7 @@ Testing with a ["Hello World" Example](https://github.com/diplfranzhoepfinger/es
 | USB_D+   | 14         | J3-19            | 3.3V            | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | J3-18            | 0.0V            | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
 | SPICS1   | 28         | J3-17            |                 | I/O/T | SPICS1, **GPIO26**                                                                                 |
+| SPICS1   | 28         | J3-16            |                 | I/O/T | **GPIO33**                                                                                 |
 | GPIO35   | 28         | J3-14            | 0.0V            | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | J3-13            | 0.0V            | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | J3-12            | 0.0V            | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ There's a really [handy spreadsheet here](ESP32-Pin-Allocation.xlsx) provided by
 | USB_D-   | 13         | I/O/T | RTC_GPIO19, GPIO19, U1RTS, ADC2_CH8, CLK_OUT2, **USB_D-**                                          |
 | USB_D+   | 14         | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
+| SPICS1   | 28         | I/O/T | SPICS1, **GPIO26**                                                                                 |
 | GPIO35   | 28         | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ There's a really [handy spreadsheet here](ESP32-Pin-Allocation.xlsx) provided by
 | USB_D-   | 13         | I/O/T | RTC_GPIO19, GPIO19, U1RTS, ADC2_CH8, CLK_OUT2, **USB_D-**                                          |
 | USB_D+   | 14         | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
-| SPICS1   | 28         | I/O/T | SPICS1, **GPIO26**                                                                                 |
+| SPICS1   | 26         | I/O/T | SPICS1, **GPIO26**                                                                                 |
+| GPIO33   | 28         | I/O/T | **GPIO33**                                                                                 |
 | GPIO35   | 28         | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ There's a really [handy spreadsheet here](ESP32-Pin-Allocation.xlsx) provided by
 | USB_D-   | 13         | I/O/T | RTC_GPIO19, GPIO19, U1RTS, ADC2_CH8, CLK_OUT2, **USB_D-**                                          |
 | USB_D+   | 14         | I/O/T | RTC_GPIO20, GPIO20, U1CTS, ADC2_CH9, CLK_OUT1, **USB_D+**                                          |
 | GPIO21   | 23         | I/O/T | RTC_GPIO21, **GPIO21**                                                                             |
-| SPICS1   | 26         | I/O/T | SPICS1, **GPIO26**                                                                                 |
-| GPIO33   | 28         | I/O/T | **GPIO33**                                                                                 |
+| SPICS1   |            | I/O/T | SPICS1, **GPIO26**                                                                                 |
+| GPIO33   |            | I/O/T | **GPIO33**                                                                                         |
+| GPIO34   |            | I/O/T | **GPIO33**                                                                                         |
 | GPIO35   | 28         | I/O/T | SPIIO6, **GPIO35**, FSPID, SUBSPID                                                                 |
 | GPIO36   | 29         | I/O/T | SPIIO7, **GPIO36**, FSPICLK, SUBSPICLK                                                             |
 | GPIO37   | 30         | I/O/T | SPIDQS, **GPIO37**, FSPIQ, SUBSPIQ                                                                 |


### PR DESCRIPTION
- Include SPICS1 pin mapping to GPIO26 in the pin configuration tables for ESP32-S3 DevKitM-1 and README.md.
