### PR TITLE
Note that GPIO39 has pull-up enabled at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,28 @@ For modules that include Octal PSRAM (any module that has 8MB PSRAM) you **MUST 
 
 GPIO39, GPIO40, GPIO41, GPIO42
 
-The behaviour of these pins is determined by eFuses in conjunction with GPIO3.  By default, if you haven't burnt any eFuses yet, these pins are safe to use.  JTAG will be available over USB.
+The behaviour of these pins is determined by eFuses in conjunction with GPIO3.  By default, if you haven't burnt any eFuses yet, these pins are safe to use*.  JTAG will be available over USB.
 
 If you wish to use these pins for JTAG, you must burn some eFuses, and control GPIO3 at start up.  See the datasheet section 2.6.4 for full details.
+
+*Some of the JTAG pins start pulled-up at boot:
+
+| JTAG Pin | Download boot | SPI boot (default) |
+|---------------|-----------------------|-----------|
+GPIO39 | Pull-up | Pull-up*
+GPIO40 | Pull-up | Floating
+GPIO41 | Floating | Floating
+GPIO42 | Floating | Floating
+
+GPIO39 starts pulled-up at boot. This can be fixed by burning EFUSE_DIS_PAD_JTAG (a.k.a. HARD_DIS_JTAG) to **permanently** disable the JTAG pins. JTAG will still be available over the USB port.
+
+GPIO39 & GPIO40 are also pulled-up when in the 'download boot mode - regardless of eFuse state.
 
 # UART Pins
 
 GPIO43, GPIO44
 
-These default to UART0 until they are used by your code.
+These default to UART0 until they are used by your code. They both start with pull-up resistors enabled.
 
 # ADC Pins
 


### PR DESCRIPTION
I learned the hard way that GPIO39 has pull-up enabled at boot. Luckily, it can be disabled by burning an eFuse.  However, the eFuse has a different name in espefuse.py than in the technical reference manual ([https://esp32.com/viewtopic.php?t=32425](https://esp32.com/viewtopic.php?t=32425)) so I've included both names.

To be clear, I have used this fix (espefuse.py -p /dev/ttyACM0 burn_efuse HARD_DIS_JTAG) on one of my boards, and verified that GPIO39 would no longer pull-up (and turn on a connected mosfet) at boot.

From the same hardware testing, I can say that both GPIO39 & GPIO40 are pulled-up during download-boot mode, and this continued to happen after burning the eFuse.

As an afterthought, the UART0 pins both start with pull-up enabled. This is easy to overlook, but can important when using them for other functions.