### PR TITLE
fix: ESP32-S3-DevKitC Wi-Fi issues (pin 21 / TX power)

### DIFF
--- a/ESP32-S3-DevKitC-1.md
+++ b/ESP32-S3-DevKitC-1.md
@@ -63,7 +63,10 @@ Testing with a ["Hello World" Example](https://github.com/diplfranzhoepfinger/es
 | GPIO48   | 25         | J3-16            | 0.0V            | I/O/T | SPICLK_N_DIFF, **GPIO48**, SUBSPICLK_N_DIFF                                                        |
 
 
+## Additional notes
 
-GPIO47 was seen 3.3V on some Modules. 
-
+- GPIO47 was seen 3.3V on some modules.
+- Some modules seem to have Wi-Fi issues when GPIO21 is used (see [here](https://esp32.com/viewtopic.php?t=41899) and [here](https://esp32.com/viewtopic.php?t=41895)). Potential fixes:
+  - Try to lower TX power to 11-13 dBm
+  - Disconnect any peripherals attached to i
 


### PR DESCRIPTION
On my S3 DevKitC I noticed abnormally high failure rates while using Wi-Fi. Apparently this issue is not a single defective unit but a general problem on some of these boards.
In my case I couldn't easily remove the attached device on the GPIO, so I only tested the reduced TX power - with success.

Since your repository was really useful for development I thought it might be a good idea to add a note about it.